### PR TITLE
Use dedicated highlight groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,21 @@ Install with any package manager of your choosing, e.g. [`folke/lazy.nvim`](http
 There are just a few options to configure, with the following defaults:
 ```lua
 {
-    -- Highlight groups to use for the everything non-comment (`backdrop`) and
-    -- the comments (`comment`).
-    highlights = {
-        backdrop = "Comment",
-        comment = "Search",
-    },
     -- Base priority to render highlight groups with. The actual priorities
     -- used by `comment-highlights.nvim` are derived from this value.
     base_priority = 200,
 }
 ```
 
-<details><summary>Example with a custom highlight group</summary>
+### 🎨 Highlight Groups
+The style of the backdrop and comments can be configured using the two highlight groups
+- `CommentHighlightsBackdrop` (linked to the `Comment` highlight group per default) and
+- `CommentHighlightsComment` (linked to the `Search` highlight group per default).
+
+The default value will be used if the respective highlight group is not already defined when the plugin is loaded.
+The groups can be set by the user or a color theme.
+
+<details><summary>Example with custom highlight groups</summary>
 
 ```lua
 {
@@ -73,16 +75,17 @@ There are just a few options to configure, with the following defaults:
             desc = "Toggle comment highlighting"
         },
     },
-    config = function ()
-        vim.api.nvim_set_hl(0, "CommentHighlights", {
-            fg = "#FFFFFF",
-            bg = "#FF0000"
+    config = function()
+        vim.api.nvim_set_hl(0, "CommentHighlightsBackdrop", {
+            bg = "#424242",
+            fg = "#424242",
         })
-        require("comment-highlights").setup({
-            highlights = {
-                comment = "CommentHighlights"
-            }
+        vim.api.nvim_set_hl(0, "CommentHighlightsComment", {
+            bg = "#FFFFFF",
+            fg = "#FF0000",
         })
+
+        require("comment-highlights").setup()
     end,
 },
 ```

--- a/lua/comment-highlights/init.lua
+++ b/lua/comment-highlights/init.lua
@@ -39,7 +39,7 @@ local function redraw_comment_hls(comment_tree)
 
     -- NOTE: Some injected languages may not have highlight queries.
     if not query:query() then
-      return
+        return
     end
 
     local root = comment_tree:root()
@@ -47,28 +47,28 @@ local function redraw_comment_hls(comment_tree)
     local iter = query:query():iter_captures(root, buf_highlighter.bufnr, row_start, row_end + 1)
 
     for capture, node, metadata in iter do
-      local hl = query.hl_cache[capture]
-      local node_range = {node:range()}
+        local hl = query.hl_cache[capture]
+        local node_range = { node:range() }
 
-      if hl then
-        local c = query._query.captures[capture] -- name of the capture in the query
+        if hl then
+            local c = query._query.captures[capture] -- name of the capture in the query
 
-        if c ~= nil then
-            local redraw_prio = nil
-            if metadata.priority ~= nil then
-                redraw_prio = M.state.priorities.redraw_base + metadata.priority
-            end
+            if c ~= nil then
+                local redraw_prio = nil
+                if metadata.priority ~= nil then
+                    redraw_prio = M.state.priorities.redraw_base + metadata.priority
+                end
 
-            vim.api.nvim_buf_set_extmark(0, M.state.ns_id, node_range[1], node_range[2], {
+                vim.api.nvim_buf_set_extmark(0, M.state.ns_id, node_range[1], node_range[2], {
                     hl_group = "@" .. c,
                     end_row = node_range[3],
                     hl_eol = false,
                     end_col = node_range[4],
                     priority = redraw_prio,
                     strict = false,
-            })
+                })
+            end
         end
-      end
     end
 end
 
@@ -80,15 +80,15 @@ local function highlight_tree(tree, ltree)
         return
     end
 
-    local root_range = {tree:root():range()}
+    local root_range = { tree:root():range() }
     for line = root_range[1], root_range[3] do
         vim.api.nvim_buf_set_extmark(0, M.state.ns_id, line, 0, {
-                hl_group = M.opts.highlights.backdrop,
-                end_row = line,
-                hl_eol = true,
-                end_col = 999,
-                priority = M.state.priorities.backdrop,
-                strict = false,
+            hl_group = M.opts.highlights.backdrop,
+            end_row = line,
+            hl_eol = true,
+            end_col = 999,
+            priority = M.state.priorities.backdrop,
+            strict = false,
         })
     end
 
@@ -100,15 +100,15 @@ local function highlight_tree(tree, ltree)
 
     local comments = res
     for _, node, _ in comments:iter_captures(tree:root(), 0) do
-        local range = {node:range(false)}
+        local range = { node:range(false) }
 
         vim.api.nvim_buf_set_extmark(0, M.state.ns_id, range[1], range[2], {
-                hl_group = M.opts.highlights.comment,
-                end_row = range[3],
-                hl_eol = false,
-                end_col = range[4],
-                priority = M.state.priorities.comment,
-                strict = false,
+            hl_group = M.opts.highlights.comment,
+            end_row = range[3],
+            hl_eol = false,
+            end_col = range[4],
+            priority = M.state.priorities.comment,
+            strict = false,
         })
     end
 end

--- a/plugin/comment-highlights.lua
+++ b/plugin/comment-highlights.lua
@@ -1,3 +1,3 @@
-vim.api.nvim_create_user_command("CHToggle", function ()
+vim.api.nvim_create_user_command("CHToggle", function()
     require("comment-highlights").toggle()
 end, {})

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,3 @@
+indent_type = "Spaces"
+indent_width = 4
+column_width = 100


### PR DESCRIPTION
With this PR, styling of the backdrop and comments via `opts.highlights` is being **deprecated**.[^1]

Instead, users are now supposed to configure the style using the dedicated highlight groups
- `CommentHighlightsBackdrop` and
- `CommentHighlightsComment`.

These can be set by the user or a color theme. If the highlight groups are not defined when the plugin is loaded, they are linked to the `Comment` and `Search` highlight groups by default.

Closes #1.

[^1]: Legacy configurations are still supported for the moment but will be removed in a future release.